### PR TITLE
Antag Rolebans: Fix backing tech debt and prefix use

### DIFF
--- a/Content.Client/Administration/UI/BanPanel/BanPanel.xaml.cs
+++ b/Content.Client/Administration/UI/BanPanel/BanPanel.xaml.cs
@@ -24,7 +24,7 @@ namespace Content.Client.Administration.UI.BanPanel;
 [GenerateTypedNameReferences]
 public sealed partial class BanPanel : DefaultWindow
 {
-    public event Action<string?, (IPAddress, int)?, bool, ImmutableTypedHwid?, bool, uint, string, NoteSeverity, string[]?, bool>? BanSubmitted;
+    public event Action<Ban>? BanSubmitted;
     public event Action<string>? PlayerChanged;
     private string? PlayerUsername { get; set; }
     private (IPAddress, int)? IpAddress { get; set; }
@@ -34,14 +34,11 @@ public sealed partial class BanPanel : DefaultWindow
     private bool HasBanFlag { get; set; }
     private TimeSpan? ButtonResetOn { get; set; }
 
-    private const string PrefixAntag = SharedRoleSystem.RolePrefixAntag;
-    private const string PrefixJob = SharedRoleSystem.RolePrefixJob;
-
     // This is less efficient than just holding a reference to the root control and enumerating children, but you
     // have to know how the controls are nested, which makes the code more complicated.
     // Role group name -> the role buttons themselves.
-    private readonly Dictionary<string, List<Button>> _roleCheckboxes = new();
-    private readonly ISawmill _banpanelSawmill;
+    private readonly Dictionary<string, List<(Button, IPrototype)>> _roleCheckboxes = new();
+    private readonly ISawmill _banPanelSawmill;
 
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!;
@@ -82,7 +79,7 @@ public sealed partial class BanPanel : DefaultWindow
     {
         RobustXamlLoader.Load(this);
         IoCManager.InjectDependencies(this);
-        _banpanelSawmill = _logManager.GetSawmill("admin.banpanel");
+        _banPanelSawmill = _logManager.GetSawmill("admin.banpanel");
         PlayerList.OnSelectionChanged += OnPlayerSelectionChanged;
         PlayerNameLine.OnFocusExit += _ => OnPlayerNameChanged();
         PlayerCheckbox.OnPressed += _ =>
@@ -113,7 +110,7 @@ public sealed partial class BanPanel : DefaultWindow
             TypeOption.SelectId(args.Id);
             OnTypeChanged();
         };
-        LastConnCheckbox.OnPressed += args =>
+        LastConnCheckbox.OnPressed += _ =>
         {
             IpLine.ModulateSelfOverride = null;
             HwidLine.ModulateSelfOverride = null;
@@ -162,19 +159,19 @@ public sealed partial class BanPanel : DefaultWindow
         {
             var roles = proto.Roles.Select(x => _protoMan.Index(x))
                              .OrderBy(x => x.ID);
-            CreateRoleGroup(proto.ID, PrefixJob, proto.Color, roles);
+            CreateRoleGroup(proto.ID, proto.Color, roles);
         }
 
         var antagRoles = _protoMan.EnumeratePrototypes<AntagPrototype>()
                                   .OrderBy(x => x.ID);
-        CreateRoleGroup("Antagonist", PrefixAntag, Color.Red, antagRoles);
+        CreateRoleGroup(AntagPrototype.GroupName, AntagPrototype.GroupColor, antagRoles);
     }
 
     /// <summary>
     /// Creates a "Role group" which stores information and logic for one "group" of roll bans.
     /// For example, all antags are one group, logi is a group, medical is a group, etc...
     /// </summary>
-    private void CreateRoleGroup<T>(string groupName, string groupPrefix, Color color, IEnumerable<T> roles) where T : class, IPrototype
+    private void CreateRoleGroup<T>(string groupName, Color color, IEnumerable<T> roles) where T : class, IPrototype
     {
         var outerContainer = new BoxContainer
         {
@@ -208,7 +205,7 @@ public sealed partial class BanPanel : DefaultWindow
         // Add the roles themselves
         foreach (var role in roles)
         {
-            AddRoleCheckbox(groupName, groupPrefix, role.ID, innerContainer, roleGroupCheckbox);
+            AddRoleCheckbox(groupName, role.ID, innerContainer, roleGroupCheckbox);
         }
 
         outerContainer.AddChild(innerContainer);
@@ -239,14 +236,14 @@ public sealed partial class BanPanel : DefaultWindow
         {
             foreach (var role in _roleCheckboxes[groupName])
             {
-                role.Pressed = args.Pressed;
+                role.Item1.Pressed = args.Pressed;
             }
 
             if (args.Pressed)
             {
                 if (!Enum.TryParse(_cfg.GetCVar(CCVars.DepartmentBanDefaultSeverity), true, out NoteSeverity newSeverity))
                 {
-                    _banpanelSawmill
+                    _banPanelSawmill
                         .Warning("Departmental role ban severity could not be parsed from config!");
                     return;
                 }
@@ -258,14 +255,14 @@ public sealed partial class BanPanel : DefaultWindow
                 {
                     foreach (var button in roleButtons)
                     {
-                        if (button.Pressed)
+                        if (button.Item1.Pressed)
                             return;
                     }
                 }
 
                 if (!Enum.TryParse(_cfg.GetCVar(CCVars.RoleBanDefaultSeverity), true, out NoteSeverity newSeverity))
                 {
-                    _banpanelSawmill
+                    _banPanelSawmill
                         .Warning("Role ban severity could not be parsed from config!");
                     return;
                 }
@@ -297,30 +294,43 @@ public sealed partial class BanPanel : DefaultWindow
     }
 
     /// <summary>
-    /// Adds a checkbutton specifically for one "role" in a "group"
+    /// Adds a check button specifically for one "role" in a "group"
     /// E.g. it would add the Chief Medical Officer "role" into the "Medical" group.
     /// </summary>
-    private void AddRoleCheckbox(string group, string prefix, string role, GridContainer roleGroupInnerContainer, Button roleGroupCheckbox)
+    private void AddRoleCheckbox(string group, string role, GridContainer roleGroupInnerContainer, Button roleGroupCheckbox)
     {
         var roleCheckboxContainer = new BoxContainer();
         var roleCheckButton = new Button
         {
-            Name = $"{prefix+role}",
+            Name = role,
             Text = role,
             ToggleMode = true,
         };
         roleCheckButton.OnToggled += args =>
         {
             // Checks the role group checkbox if all the children are pressed
-            if (args.Pressed && _roleCheckboxes[group].All(e => e.Pressed))
+            if (args.Pressed && _roleCheckboxes[group].All(e => e.Item1.Pressed))
                 roleGroupCheckbox.Pressed = args.Pressed;
             else
                 roleGroupCheckbox.Pressed = false;
         };
 
+        IPrototype rolePrototype;
+
+        if (_protoMan.TryIndex<JobPrototype>(role, out var jobPrototype))
+            rolePrototype = jobPrototype;
+        else if (_protoMan.TryIndex<AntagPrototype>(role, out var antagPrototype))
+            rolePrototype = antagPrototype;
+        else
+        {
+            _banPanelSawmill.Error($"Adding a role checkbox for role {role}: role is not a JobPrototype or AntagPrototype.");
+
+            return;
+        }
+
         // This is adding the icon before the role name
         // Yeah, this is sus, but having to split the functions up and stuff is worse imo.
-        if (_protoMan.TryIndex<JobPrototype>(role, out var jobPrototype) && _protoMan.TryIndex(jobPrototype.Icon, out var iconProto))
+        if (jobPrototype is not null && _protoMan.TryIndex(jobPrototype.Icon, out var iconProto))
         {
             var jobIconTexture = new TextureRect
             {
@@ -337,7 +347,7 @@ public sealed partial class BanPanel : DefaultWindow
         roleGroupInnerContainer.AddChild(roleCheckboxContainer);
 
         _roleCheckboxes.TryAdd(group, []);
-        _roleCheckboxes[group].Add(roleCheckButton);
+        _roleCheckboxes[group].Add((roleCheckButton, rolePrototype));
     }
 
     public void UpdateBanFlag(bool newFlag)
@@ -490,7 +500,7 @@ public sealed partial class BanPanel : DefaultWindow
                     newSeverity = serverSeverity;
                 else
                 {
-                    _banpanelSawmill
+                    _banPanelSawmill
                         .Warning("Server ban severity could not be parsed from config!");
                 }
 
@@ -503,7 +513,7 @@ public sealed partial class BanPanel : DefaultWindow
                     }
                     else
                     {
-                        _banpanelSawmill
+                        _banPanelSawmill
                             .Warning("Role ban severity could not be parsed from config!");
                     }
                     break;
@@ -548,34 +558,51 @@ public sealed partial class BanPanel : DefaultWindow
 
     private void SubmitButtonOnOnPressed(BaseButton.ButtonEventArgs obj)
     {
-        string[]? roles = null;
+        ProtoId<JobPrototype>[]? jobs = null;
+        ProtoId<AntagPrototype>[]? antags = null;
+
         if (TypeOption.SelectedId == (int) Types.Role)
         {
-            var rolesList = new List<string>();
+            var jobList = new List<ProtoId<JobPrototype>>();
+            var antagList = new List<ProtoId<AntagPrototype>>();
+
             if (_roleCheckboxes.Count == 0)
                 throw new DebugAssertException("RoleCheckboxes was empty");
 
             foreach (var button in _roleCheckboxes.Values.SelectMany(departmentButtons => departmentButtons))
             {
-                if (button is { Pressed: true, Name: not null })
+                if (button.Item1 is { Pressed: true, Name: not null })
                 {
-                    rolesList.Add(button.Name);
+                    switch (button.Item2)
+                    {
+                        case JobPrototype:
+                            jobList.Add(button.Item2.ID);
+
+                            break;
+                        case AntagPrototype:
+                            antagList.Add(button.Item2.ID);
+
+                            break;
+                    }
                 }
             }
 
-            if (rolesList.Count == 0)
+            if (jobList.Count == 0)
             {
                 Tabs.CurrentTab = (int) TabNumbers.Roles;
+
                 return;
             }
 
-            roles = rolesList.ToArray();
+            jobs = jobList.ToArray();
+            antags = antagList.ToArray();
         }
 
         if (TypeOption.SelectedId == (int) Types.None)
         {
             TypeOption.ModulateSelfOverride = Color.Red;
             Tabs.CurrentTab = (int) TabNumbers.BasicInfo;
+
             return;
         }
 
@@ -587,6 +614,7 @@ public sealed partial class BanPanel : DefaultWindow
             ReasonTextEdit.GrabKeyboardFocus();
             ReasonTextEdit.ModulateSelfOverride = Color.Red;
             ReasonTextEdit.OnKeyBindDown += ResetTextEditor;
+
             return;
         }
 
@@ -595,6 +623,7 @@ public sealed partial class BanPanel : DefaultWindow
             ButtonResetOn = _gameTiming.CurTime.Add(TimeSpan.FromSeconds(3));
             SubmitButton.ModulateSelfOverride = Color.Red;
             SubmitButton.Text = Loc.GetString("ban-panel-confirm");
+
             return;
         }
 
@@ -603,7 +632,22 @@ public sealed partial class BanPanel : DefaultWindow
         var useLastHwid = HwidCheckbox.Pressed && LastConnCheckbox.Pressed && Hwid is null;
         var severity = (NoteSeverity) SeverityOption.SelectedId;
         var erase = EraseCheckbox.Pressed;
-        BanSubmitted?.Invoke(player, IpAddress, useLastIp, Hwid, useLastHwid, (uint) (TimeEntered * Multiplier), reason, severity, roles, erase);
+
+        var ban = new Ban(
+            player,
+            IpAddress,
+            useLastIp,
+            Hwid,
+            useLastHwid,
+            (uint)(TimeEntered * Multiplier),
+            reason,
+            severity,
+            jobs,
+            antags,
+            erase
+        );
+
+        BanSubmitted?.Invoke(ban);
     }
 
     protected override void FrameUpdate(FrameEventArgs args)

--- a/Content.Client/Administration/UI/BanPanel/BanPanelEui.cs
+++ b/Content.Client/Administration/UI/BanPanel/BanPanelEui.cs
@@ -14,8 +14,7 @@ public sealed class BanPanelEui : BaseEui
     {
         BanPanel = new BanPanel();
         BanPanel.OnClose += () => SendMessage(new CloseEuiMessage());
-        BanPanel.BanSubmitted += (player, ip, useLastIp, hwid, useLastHwid, minutes, reason, severity, roles, erase)
-            => SendMessage(new BanPanelEuiStateMsg.CreateBanRequest(player, ip, useLastIp, hwid, useLastHwid, minutes, reason, severity, roles, erase));
+        BanPanel.BanSubmitted += ban => SendMessage(new BanPanelEuiStateMsg.CreateBanRequest(ban));
         BanPanel.PlayerChanged += player => SendMessage(new BanPanelEuiStateMsg.GetPlayerInfoRequest(player));
     }
 

--- a/Content.Server/Administration/BanPanelEui.cs
+++ b/Content.Server/Administration/BanPanelEui.cs
@@ -49,7 +49,7 @@ public sealed class BanPanelEui : BaseEui
         switch (msg)
         {
             case BanPanelEuiStateMsg.CreateBanRequest r:
-                BanPlayer(r.Player, r.IpAddress, r.UseLastIp, r.Hwid, r.UseLastHwid, r.Minutes, r.Severity, r.Reason, r.Roles, r.Erase);
+                BanPlayer(r.Ban);
                 break;
             case BanPanelEuiStateMsg.GetPlayerInfoRequest r:
                 ChangePlayer(r.PlayerUsername);
@@ -57,29 +57,26 @@ public sealed class BanPanelEui : BaseEui
         }
     }
 
-    private async void BanPlayer(string? target, string? ipAddressString, bool useLastIp, ImmutableTypedHwid? hwid, bool useLastHwid, uint minutes, NoteSeverity severity, string reason, IReadOnlyCollection<string>? roles, bool erase)
+    private async void BanPlayer(Ban ban)
     {
         if (!_admins.HasAdminFlag(Player, AdminFlags.Ban))
         {
             _sawmill.Warning($"{Player.Name} ({Player.UserId}) tried to create a ban with no ban flag");
+
             return;
         }
-        if (target == null && string.IsNullOrWhiteSpace(ipAddressString) && hwid == null)
+
+        if (ban.Target == null && string.IsNullOrWhiteSpace(ban.IpAddress) && ban.Hwid == null)
         {
             _chat.DispatchServerMessage(Player, Loc.GetString("ban-panel-no-data"));
+
             return;
         }
 
         (IPAddress, int)? addressRange = null;
-        if (ipAddressString is not null)
+        if (ban.IpAddress is not null)
         {
-            var hid = "0";
-            var split = ipAddressString.Split('/', 2);
-            ipAddressString = split[0];
-            if (split.Length > 1)
-                hid = split[1];
-
-            if (!IPAddress.TryParse(ipAddressString, out var ipAddress) || !uint.TryParse(hid, out var hidInt) || hidInt > Ipv6_CIDR || hidInt > Ipv4_CIDR && ipAddress.AddressFamily == AddressFamily.InterNetwork)
+            if (!IPAddress.TryParse(ban.IpAddress, out var ipAddress) || !uint.TryParse(ban.IpAddressHid, out var hidInt) || hidInt > Ipv6_CIDR || hidInt > Ipv4_CIDR && ipAddress.AddressFamily == AddressFamily.InterNetwork)
             {
                 _chat.DispatchServerMessage(Player, Loc.GetString("ban-panel-invalid-ip"));
                 return;
@@ -91,12 +88,12 @@ public sealed class BanPanelEui : BaseEui
             addressRange = (ipAddress, (int) hidInt);
         }
 
-        var targetUid = target is not null ? PlayerId : null;
-        addressRange = useLastIp && LastAddress is not null ? (LastAddress, LastAddress.AddressFamily == AddressFamily.InterNetworkV6 ? Ipv6_CIDR : Ipv4_CIDR) : addressRange;
-        var targetHWid = useLastHwid ? LastHwid : hwid;
-        if (target != null && target != PlayerName || Guid.TryParse(target, out var parsed) && parsed != PlayerId)
+        var targetUid = ban.Target is not null ? PlayerId : null;
+        addressRange = ban.UseLastIp && LastAddress is not null ? (LastAddress, LastAddress.AddressFamily == AddressFamily.InterNetworkV6 ? Ipv6_CIDR : Ipv4_CIDR) : addressRange;
+        var targetHWid = ban.UseLastHwid ? LastHwid : ban.Hwid;
+        if (ban.Target != null && ban.Target != PlayerName || Guid.TryParse(ban.Target, out var parsed) && parsed != PlayerId)
         {
-            var located = await _playerLocator.LookupIdByNameOrIdAsync(target);
+            var located = await _playerLocator.LookupIdByNameOrIdAsync(ban.Target);
             if (located == null)
             {
                 _chat.DispatchServerMessage(Player, Loc.GetString("cmd-ban-player"));
@@ -104,7 +101,7 @@ public sealed class BanPanelEui : BaseEui
             }
             targetUid = located.UserId;
             var targetAddress = located.LastAddress;
-            if (useLastIp && targetAddress != null)
+            if (ban.UseLastIp && targetAddress != null)
             {
                 if (targetAddress.IsIPv4MappedToIPv6)
                     targetAddress = targetAddress.MapToIPv4();
@@ -113,23 +110,50 @@ public sealed class BanPanelEui : BaseEui
                 var hid = targetAddress.AddressFamily == AddressFamily.InterNetworkV6 ? Ipv6_CIDR : Ipv4_CIDR;
                 addressRange = (targetAddress, hid);
             }
-            targetHWid = useLastHwid ? located.LastHWId : hwid;
+            targetHWid = ban.UseLastHwid ? located.LastHWId : ban.Hwid;
         }
 
-        if (roles?.Count > 0)
+        if (ban.BannedJobs?.Length > 0 || ban.BannedAntags?.Length > 0)
         {
             var now = DateTimeOffset.UtcNow;
-            foreach (var role in roles)
+            foreach (var role in ban.BannedJobs ?? [])
             {
-                _banManager.CreateRoleBan(targetUid, target, Player.UserId, addressRange, targetHWid, role, minutes, severity, reason, now);
+                _banManager.CreateRoleBan(
+                    targetUid,
+                    ban.Target,
+                    Player.UserId,
+                    addressRange,
+                    targetHWid,
+                    role,
+                    ban.BanDurationMinutes,
+                    ban.Severity,
+                    ban.Reason,
+                    now
+                );
+            }
+
+            foreach (var role in ban.BannedAntags ?? [])
+            {
+                _banManager.CreateRoleBan(
+                    targetUid,
+                    ban.Target,
+                    Player.UserId,
+                    addressRange,
+                    targetHWid,
+                    role,
+                    ban.BanDurationMinutes,
+                    ban.Severity,
+                    ban.Reason,
+                    now
+                );
             }
 
             Close();
+
             return;
         }
 
-        if (erase &&
-            targetUid != null)
+        if (ban.Erase && targetUid is not null)
         {
             try
             {
@@ -142,7 +166,16 @@ public sealed class BanPanelEui : BaseEui
             }
         }
 
-        _banManager.CreateServerBan(targetUid, target, Player.UserId, addressRange, targetHWid, minutes, severity, reason);
+        _banManager.CreateServerBan(
+            targetUid,
+            ban.Target,
+            Player.UserId,
+            addressRange,
+            targetHWid,
+            ban.BanDurationMinutes,
+            ban.Severity,
+            ban.Reason
+        );
 
         Close();
     }

--- a/Content.Server/Administration/Managers/IBanManager.cs
+++ b/Content.Server/Administration/Managers/IBanManager.cs
@@ -52,15 +52,35 @@ public interface IBanManager
     public HashSet<ProtoId<JobPrototype>>? GetJobBans(NetUserId playerUserId);
 
     /// <summary>
+    /// Gets a list of prototype IDs with the player's antag bans.
+    /// </summary>
+    public HashSet<ProtoId<AntagPrototype>>? GetAntagBans(NetUserId playerUserId);
+
+    /// <summary>
     /// Creates a job ban for the specified target, username or GUID
     /// </summary>
     /// <param name="target">Target user, username or GUID, null for none</param>
-    /// <param name="role">Role ID to be banned from. It must be prefixed to designate the type ('Job:' or 'Antag:')</param>
+    /// <param name="targetUsername">The username of the target, if known</param>
+    /// <param name="banningAdmin">The responsible admin for the ban</param>
+    /// <param name="addressRange">The range of IPs that are to be banned, if known</param>
+    /// <param name="hwid">The HWID to be banned, if known</param>
+    /// <param name="role">The role ID to be banned from. Either an AntagPrototype or a JobPrototype</param>
+    /// <param name="minutes">Number of minutes to ban for. 0 and null mean permanent</param>
     /// <param name="severity">Severity of the resulting ban note</param>
     /// <param name="reason">Reason for the ban</param>
-    /// <param name="minutes">Number of minutes to ban for. 0 and null mean permanent</param>
     /// <param name="timeOfBan">Time when the ban was applied, used for grouping role bans</param>
-    public void CreateRoleBan(NetUserId? target, string? targetUsername, NetUserId? banningAdmin, (IPAddress, int)? addressRange, ImmutableTypedHwid? hwid, string role, uint? minutes, NoteSeverity severity, string reason, DateTimeOffset timeOfBan);
+    public void CreateRoleBan<T>(
+        NetUserId? target,
+        string? targetUsername,
+        NetUserId? banningAdmin,
+        (IPAddress, int)? addressRange,
+        ImmutableTypedHwid? hwid,
+        ProtoId<T> role,
+        uint? minutes,
+        NoteSeverity severity,
+        string reason,
+        DateTimeOffset timeOfBan
+    ) where T : class, IPrototype;
 
     /// <summary>
     /// Pardons a role ban for the specified target, username or GUID

--- a/Content.Server/Database/ServerDbBase.cs
+++ b/Content.Server/Database/ServerDbBase.cs
@@ -28,9 +28,6 @@ namespace Content.Server.Database
     public abstract class ServerDbBase
     {
         private readonly ISawmill _opsLog;
-        private const string PrefixJob = SharedRoleSystem.RolePrefixJob;
-        private const string AntagPrefix = SharedRoleSystem.RolePrefixAntag;
-
         public event Action<DatabaseNotification>? OnNotificationReceived;
 
         /// <param name="opsLog">Sawmill to trace log database operations to.</param>
@@ -1388,7 +1385,7 @@ INSERT INTO player_round (players_id, rounds_id) VALUES ({players[player]}, {id}
                 ban.LastEditedAt,
                 ban.ExpirationTime,
                 ban.Hidden,
-                new [] { ban.RoleId.Replace(PrefixJob, null).Replace(AntagPrefix, null) },
+                new [] { ban.RoleId.Replace(BanManager.PrefixJob, null).Replace(BanManager.PrefixAntag, null) },
                 MakePlayerRecord(unbanningAdmin),
                 ban.Unban?.UnbanTime);
         }
@@ -1688,7 +1685,7 @@ INSERT INTO player_round (players_id, rounds_id) VALUES ({players[player]}, {id}
                     NormalizeDatabaseTime(firstBan.LastEditedAt),
                     NormalizeDatabaseTime(firstBan.ExpirationTime),
                     firstBan.Hidden,
-                    banGroup.Select(ban => ban.RoleId.Replace(PrefixJob, null).Replace(AntagPrefix, null)).ToArray(),
+                    banGroup.Select(ban => ban.RoleId.Replace(BanManager.PrefixJob, null).Replace(BanManager.PrefixAntag, null)).ToArray(),
                     MakePlayerRecord(unbanningAdmin),
                     NormalizeDatabaseTime(firstBan.Unban?.UnbanTime)));
             }

--- a/Content.Shared/Administration/BanPanelEuiState.cs
+++ b/Content.Shared/Administration/BanPanelEuiState.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using Content.Shared.Database;
 using Content.Shared.Eui;
+using Content.Shared.Roles;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Administration;
@@ -21,32 +23,9 @@ public sealed class BanPanelEuiState : EuiStateBase
 public static class BanPanelEuiStateMsg
 {
     [Serializable, NetSerializable]
-    public sealed class CreateBanRequest : EuiMessageBase
+    public sealed class CreateBanRequest(Ban ban) : EuiMessageBase
     {
-        public string? Player { get; set; }
-        public string? IpAddress { get; set; }
-        public ImmutableTypedHwid? Hwid { get; set; }
-        public uint Minutes { get; set; }
-        public string Reason { get; set; }
-        public NoteSeverity Severity { get; set; }
-        public string[]? Roles { get; set; }
-        public bool UseLastIp { get; set; }
-        public bool UseLastHwid { get; set; }
-        public bool Erase { get; set; }
-
-        public CreateBanRequest(string? player, (IPAddress, int)? ipAddress, bool useLastIp, ImmutableTypedHwid? hwid, bool useLastHwid, uint minutes, string reason, NoteSeverity severity, string[]? roles, bool erase)
-        {
-            Player = player;
-            IpAddress = ipAddress == null ? null : $"{ipAddress.Value.Item1}/{ipAddress.Value.Item2}";
-            UseLastIp = useLastIp;
-            Hwid = hwid;
-            UseLastHwid = useLastHwid;
-            Minutes = minutes;
-            Reason = reason;
-            Severity = severity;
-            Roles = roles;
-            Erase = erase;
-        }
+        public Ban Ban { get; } = ban;
     }
 
     [Serializable, NetSerializable]
@@ -59,4 +38,51 @@ public static class BanPanelEuiStateMsg
             PlayerUsername = username;
         }
     }
+}
+
+/// <summary>
+///     Contains all the data related to a particular ban action created by the BanPanel window.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed record Ban
+{
+    public Ban(
+        string? target,
+        (IPAddress, int)? ipAddressTuple,
+        bool useLastIp,
+        ImmutableTypedHwid? hwid,
+        bool useLastHwid,
+        uint banDurationMinutes,
+        string reason,
+        NoteSeverity severity,
+        ProtoId<JobPrototype>[]? bannedJobs,
+        ProtoId<AntagPrototype>[]? bannedAntags,
+        bool erase)
+    {
+        Target = target;
+        IpAddress = ipAddressTuple?.Item1.ToString();
+        IpAddressHid = ipAddressTuple?.Item2.ToString() ?? "0";
+        UseLastIp = useLastIp;
+        Hwid = hwid;
+        UseLastHwid = useLastHwid;
+        BanDurationMinutes = banDurationMinutes;
+        Reason = reason;
+        Severity = severity;
+        BannedJobs = bannedJobs;
+        BannedAntags = bannedAntags;
+        Erase = erase;
+    }
+
+    public readonly string? Target;
+    public readonly string? IpAddress;
+    public readonly string? IpAddressHid;
+    public readonly bool UseLastIp;
+    public readonly ImmutableTypedHwid? Hwid;
+    public readonly bool UseLastHwid;
+    public readonly uint BanDurationMinutes;
+    public readonly string Reason;
+    public readonly NoteSeverity Severity;
+    public readonly ProtoId<JobPrototype>[]? BannedJobs;
+    public readonly ProtoId<AntagPrototype>[]? BannedAntags;
+    public readonly bool Erase;
 }

--- a/Content.Shared/Players/MsgRoleBans.cs
+++ b/Content.Shared/Players/MsgRoleBans.cs
@@ -11,24 +11,40 @@ public sealed class MsgRoleBans : NetMessage
 {
     public override MsgGroups MsgGroup => MsgGroups.EntityEvent;
 
-    public List<string> Bans = new();
+    public List<string> JobBans = new();
+    public List<string> AntagBans = new();
 
     public override void ReadFromBuffer(NetIncomingMessage buffer, IRobustSerializer serializer)
     {
-        var count = buffer.ReadVariableInt32();
-        Bans.EnsureCapacity(count);
+        var jobCount = buffer.ReadVariableInt32();
+        JobBans.EnsureCapacity(jobCount);
 
-        for (var i = 0; i < count; i++)
+        for (var i = 0; i < jobCount; i++)
         {
-            Bans.Add(buffer.ReadString());
+            JobBans.Add(buffer.ReadString());
+        }
+
+        var antagCount = buffer.ReadVariableInt32();
+        AntagBans.EnsureCapacity(antagCount);
+
+        for (var i = 0; i < antagCount; i++)
+        {
+            AntagBans.Add(buffer.ReadString());
         }
     }
 
     public override void WriteToBuffer(NetOutgoingMessage buffer, IRobustSerializer serializer)
     {
-        buffer.WriteVariableInt32(Bans.Count);
+        buffer.WriteVariableInt32(JobBans.Count);
 
-        foreach (var ban in Bans)
+        foreach (var ban in JobBans)
+        {
+            buffer.Write(ban);
+        }
+
+        buffer.WriteVariableInt32(AntagBans.Count);
+
+        foreach (var ban in AntagBans)
         {
             buffer.Write(ban);
         }

--- a/Content.Shared/Roles/AntagPrototype.cs
+++ b/Content.Shared/Roles/AntagPrototype.cs
@@ -10,6 +10,12 @@ namespace Content.Shared.Roles;
 [Prototype]
 public sealed partial class AntagPrototype : IPrototype
 {
+    // The name to group all antagonists under. Equivalent to DepartmentPrototype IDs.
+    public static readonly string GroupName = "Antagonist";
+
+    // The colour to group all antagonists using. Equivalent to DepartmentPrototype Color fields.
+    public static readonly Color GroupColor = Color.Red;
+
     [ViewVariables]
     [IdDataField]
     public string ID { get; private set; } = default!;

--- a/Content.Shared/Roles/SharedRoleSystem.cs
+++ b/Content.Shared/Roles/SharedRoleSystem.cs
@@ -30,10 +30,6 @@ public abstract class SharedRoleSystem : EntitySystem
 
     private JobRequirementOverridePrototype? _requirementOverride;
 
-    // Prefixes used when recording or referencing role bans
-    public const string RolePrefixJob = "Job:";
-    public const string RolePrefixAntag = "Antag:";
-
     public override void Initialize()
     {
         Subs.CVar(_cfg, CCVars.GameRoleTimerOverride, SetRequirementOverride, true);


### PR DESCRIPTION
This PR resolves the whole prefixing malarky whilst keeping changes focussed to just the banning code.

Specifically:

1. Bans are now a record PODO so there's no more awful signatures of actions/bans.
2. Bit of generics use, mostly in IBanManager.
3. Store the role prototype ID of the checkbox in a tuple with its button.
4. Don't leak the `Job:` and `Antag:` decorations outside of the ban database and its wrapping code.
5. Random linting.